### PR TITLE
HTTP Basic Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Start your application:
 
 Open <https://localhost:10080/api/v1/greeting> in your browser or favorite REST API client (for example [HTTPie](https://httpie.org/), [REST Client for VSCode](https://marketplace.visualstudio.com/items?itemName=humao.rest-client), or [Insomnia](https://insomnia.rest/).
 
+Use `zowe` as the username and `zowe` as the password.
+
 The default page <https://localhost:10080/> opens Swagger UI with the API Documentation.
 
 ## Customize and Extend Your Application

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'com.ca.mfaas.sdk:mfaas-integration-enabler-java:1.1.2'
     implementation 'io.springfox:springfox-swagger2:2.9.2'
     implementation 'io.springfox:springfox-swagger-ui:2.9.2'

--- a/src/main/java/org/zowe/sample/apiservice/CsrfController.java
+++ b/src/main/java/org/zowe/sample/apiservice/CsrfController.java
@@ -1,0 +1,23 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.sample.apiservice;
+
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CsrfController {
+
+    @RequestMapping("/csrf")
+    public CsrfToken csrf(CsrfToken token) {
+        return token;
+    }
+}

--- a/src/main/java/org/zowe/sample/apiservice/apidoc/ApiDocConstants.java
+++ b/src/main/java/org/zowe/sample/apiservice/apidoc/ApiDocConstants.java
@@ -1,0 +1,14 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.sample.apiservice.apidoc;
+
+public final class ApiDocConstants {
+    public final static String DOC_SCHEME_BASIC_AUTH = "basicAuth";
+}

--- a/src/main/java/org/zowe/sample/apiservice/apidoc/SwaggerConfig.java
+++ b/src/main/java/org/zowe/sample/apiservice/apidoc/SwaggerConfig.java
@@ -9,7 +9,10 @@
  */
 package org.zowe.sample.apiservice.apidoc;
 
+import static org.zowe.sample.apiservice.apidoc.ApiDocConstants.DOC_SCHEME_BASIC_AUTH;
+
 import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +24,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.BasicAuth;
+import springfox.documentation.service.SecurityScheme;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -28,6 +33,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig implements WebMvcConfigurer {
+
     @Value("${apiml.service.apiInfo[0].title}")
     private String apiTitle;
 
@@ -39,14 +45,23 @@ public class SwaggerConfig implements WebMvcConfigurer {
 
     @Bean
     public Docket api() {
+        List<SecurityScheme> schemes = new ArrayList<>();
+        schemes.add(new BasicAuth(DOC_SCHEME_BASIC_AUTH));
+
         return new Docket(DocumentationType.SWAGGER_2).groupName("v1").select().apis(RequestHandlerSelectors.any())
-                .paths(PathSelectors.ant("/api/v1/*")).build().apiInfo(apiInfo())
+                .paths(PathSelectors.ant("/api/v1/*")).build().apiInfo(apiInfo()).securitySchemes(schemes)
                 .pathProvider(new BasePathProvider("/api/v1"));
     }
 
     private ApiInfo apiInfo() {
         return new ApiInfo(apiTitle, apiDescription, apiVersion, null, null, null, null, new ArrayList<>());
     }
+
+    // @Bean
+    // public SecurityConfiguration security() {
+    // return
+    // SecurityConfigurationBuilder.builder().useBasicAuthenticationWithAccessCodeGrant(true).build();
+    // }
 
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {

--- a/src/main/java/org/zowe/sample/apiservice/config/WebSecurityConfig.java
+++ b/src/main/java/org/zowe/sample/apiservice/config/WebSecurityConfig.java
@@ -1,0 +1,44 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+package org.zowe.sample.apiservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
+        http.headers().httpStrictTransportSecurity().disable();
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.httpBasic().realmName("Zowe Sample API Service");
+        http.authorizeRequests().antMatchers("/", "/swagger-ui.html", "/webjars/springfox-swagger-ui/**", "/apiDocs/**",
+                "/api/*/apiDocs", "/swagger-resources/**", "/csrf").permitAll().anyRequest().authenticated();
+    }
+
+    @Bean
+    @Override
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.withDefaultPasswordEncoder().username("zowe").password("zowe").roles("USER").build();
+
+        return new InMemoryUserDetailsManager(user);
+    }
+}

--- a/src/main/java/org/zowe/sample/apiservice/hello/GreetingController.java
+++ b/src/main/java/org/zowe/sample/apiservice/hello/GreetingController.java
@@ -9,6 +9,8 @@
  */
 package org.zowe.sample.apiservice.hello;
 
+import static org.zowe.sample.apiservice.apidoc.ApiDocConstants.DOC_SCHEME_BASIC_AUTH;
+
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +20,7 @@ import org.zowe.sample.apiservice.config.RestApiVersion1Controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
 
 @Api(tags = "Greeting", description = "REST API for greetings")
 @RestApiVersion1Controller
@@ -26,10 +29,11 @@ public class GreetingController {
     private static final String template = "Hello, %s!";
     private final AtomicLong counter = new AtomicLong();
 
-    @ApiOperation(value = "Returns a greeting for the name passed", nickname = "greetingToSomeone")
+    @ApiOperation(value = "Returns a greeting for the name passed", nickname = "greetingToSomeone", authorizations = {
+            @Authorization(value = DOC_SCHEME_BASIC_AUTH) })
     @GetMapping("/greeting")
     public Greeting greeting(
-            @ApiParam(value = "Person or object to be greeted", required = false) @RequestParam(value = "name", defaultValue = "World") String name) {
+            @ApiParam(value = "Person or object to be greeted", required = false) @RequestParam(value = "name", defaultValue = "world") String name) {
         return new Greeting(counter.incrementAndGet(), String.format(template, name));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,7 +50,7 @@ apiml:
               gatewayUrl: api/v1
               version: 1.0.0
               title: Zowe Sample REST API
-              description: Sample Spring Boot REST API for Zowe
+              description: Sample Spring Boot REST API for Zowe. Press **Authorize** and use `zowe` as the username and `zowe` as the password
               swaggerUrl: ${apiml.service.scheme}://${apiml.service.hostname}:${server.port}/api/v1/apiDocs
 
 ---

--- a/src/test/java/org/zowe/sample/apiservice/hello/GreetingControllerTests.java
+++ b/src/test/java/org/zowe/sample/apiservice/hello/GreetingControllerTests.java
@@ -31,8 +31,13 @@ public class GreetingControllerTests {
 
     @Test
     public void returnsGreeting() throws Exception {
-        mvc.perform(get("/api/v1/greeting").contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
-                .andExpect(jsonPath("$.content", is("Hello, World!")));
+        mvc.perform(get("/api/v1/greeting").header("Authorization", "Basic em93ZTp6b3dl")
+                .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", is("Hello, world!")));
     }
 
+    @Test
+    public void failsWithoutAuthentication() throws Exception {
+        mvc.perform(get("/api/v1/greeting")).andExpect(status().isUnauthorized());
+    }
 }


### PR DESCRIPTION
Secures endpoints by HTTP basic authentication. It is not using z/OS authentication that will be provided in another PR.

Use `zowe` as the username and `zowe` as the password.

Swagger documentation includes proper setup of security schemes so you can use Swagger UI (https://localhost:10080/swagger-ui.html) and **Authorize** button to perform authenticated requests.